### PR TITLE
Add Python3 PyPI classifiers

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,11 @@ setup(
     setup_requires='setuptools',
     license='Copyright 2014 Yelp',
     classifiers=[
+        'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
         'License :: OSI Approved :: Apache Software License',
         'Operating System :: OS Independent',
     ],


### PR DESCRIPTION
Since with your PR elastalert passes the test-suite with Python3, we should add PyPI classifiers.